### PR TITLE
Add trade game MVP: Prisma schema, server game logic, Expo mobile skeleton and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,65 @@
-# trade_game
+# trade_game MVP
+
+スマホ向け対戦型トレードゲームの MVP 実装です。
+
+## 技術スタック
+- Frontend: React Native + Expo Router
+- Backend: Node.js + TypeScript + Express
+- DB: PostgreSQL + Prisma
+
+## モノレポ構成
+- `apps/mobile`: Expo アプリ
+- `apps/server`: API サーバ
+- `docs/mvp-design.md`: 設計・API・優先順位
+
+## ローカル起動手順
+
+### 1) PostgreSQL 起動（例: Docker）
+```bash
+docker run --name trade-game-db -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=trade_game -p 5432:5432 -d postgres:16
+```
+
+### 2) サーバ起動
+```bash
+cd apps/server
+cp .env.example .env
+npm install
+npx prisma migrate dev --name init
+npm run seed
+npm run dev
+```
+
+- API: `http://localhost:4000`
+- Health check: `GET /health`
+
+### 3) モバイル起動
+```bash
+cd apps/mobile
+npm install
+npm run start
+```
+
+Expo の QR コードから iOS/Android シミュレータまたは実機で起動します。
+
+## MVP でできること
+- ホーム画面でユーザ情報確認
+- ログインボーナス受け取り（1日1回）
+- CPU戦開始（ライフポイント 30 消費）
+- Buy / Sell / Hold によるターン進行
+- 上下目標価格、または最大ターン到達で勝敗判定
+- 勝敗に応じてコイン報酬
+
+## API サンプル
+### CPU戦開始
+```bash
+curl -X POST http://localhost:4000/api/matches/cpu \
+  -H 'Content-Type: application/json' \
+  -d '{"userId":"demo-user","botLevel":"NORMAL"}'
+```
+
+### ターン行動送信
+```bash
+curl -X POST http://localhost:4000/api/matches/<matchId>/actions \
+  -H 'Content-Type: application/json' \
+  -d '{"userId":"demo-user","actionType":"BUY","amount":100}'
+```

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,0 +1,8 @@
+{
+  "expo": {
+    "name": "Trade Game MVP",
+    "slug": "trade-game-mvp",
+    "scheme": "tradegame",
+    "plugins": ["expo-router"]
+  }
+}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from "expo-router";
+
+export default function Layout() {
+  return <Stack screenOptions={{ headerShown: true }} />;
+}

--- a/apps/mobile/app/battle.tsx
+++ b/apps/mobile/app/battle.tsx
@@ -1,0 +1,35 @@
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useState } from "react";
+import { Button, Text, View } from "react-native";
+import { sendAction } from "../services/api";
+
+export default function BattleScreen() {
+  const router = useRouter();
+  const { matchId } = useLocalSearchParams<{ matchId: string }>();
+  const [state, setState] = useState<any>(null);
+
+  async function action(type: "BUY" | "SELL" | "HOLD") {
+    if (!matchId) return;
+    const data = await sendAction(matchId, type, type === "HOLD" ? 0 : 100);
+    setState(data.match);
+    if (data.match.status === "FINISHED") {
+      router.push({
+        pathname: "/result",
+        params: { winnerSide: data.match.winnerSide, price: data.match.currentPrice }
+      });
+    }
+  }
+
+  return (
+    <View style={{ flex: 1, gap: 10, padding: 20 }}>
+      <Text style={{ fontSize: 20, fontWeight: "700" }}>対戦画面</Text>
+      <Text>Match: {matchId}</Text>
+      <Text>現在価格: {state?.currentPrice ?? "100"}</Text>
+      <Text>ターン: {state?.turnNumber ?? 1}</Text>
+      <Text>目標価格: 上110 / 下90</Text>
+      <Button title="Buy 100" onPress={() => action("BUY")} />
+      <Button title="Sell 100" onPress={() => action("SELL")} />
+      <Button title="Hold" onPress={() => action("HOLD")} />
+    </View>
+  );
+}

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,0 +1,41 @@
+import { useRouter } from "expo-router";
+import { useEffect, useState } from "react";
+import { Button, Text, View } from "react-native";
+import { claimBonus, fetchHome, startCpuMatch } from "../services/api";
+
+export default function HomeScreen() {
+  const router = useRouter();
+  const [user, setUser] = useState<any>(null);
+
+  async function load() {
+    const data = await fetchHome();
+    setUser(data.user);
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  return (
+    <View style={{ flex: 1, gap: 12, padding: 20 }}>
+      <Text style={{ fontSize: 24, fontWeight: "700" }}>Trade Game MVP</Text>
+      <Text>ユーザー: {user?.name ?? "-"}</Text>
+      <Text>アバター: {user?.avatarId ?? "-"}</Text>
+      <Text>ライフポイント: {user?.lifePoints ?? "-"}</Text>
+      <Button
+        title="ログインボーナス受け取り"
+        onPress={async () => {
+          await claimBonus();
+          await load();
+        }}
+      />
+      <Button
+        title="CPU戦開始 (Normal)"
+        onPress={async () => {
+          const data = await startCpuMatch("NORMAL");
+          router.push({ pathname: "/battle", params: { matchId: data.match.id } });
+        }}
+      />
+    </View>
+  );
+}

--- a/apps/mobile/app/result.tsx
+++ b/apps/mobile/app/result.tsx
@@ -1,0 +1,16 @@
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { Button, Text, View } from "react-native";
+
+export default function ResultScreen() {
+  const router = useRouter();
+  const { winnerSide, price } = useLocalSearchParams<{ winnerSide: string; price: string }>();
+  return (
+    <View style={{ flex: 1, padding: 20, gap: 12 }}>
+      <Text style={{ fontSize: 24, fontWeight: "700" }}>結果</Text>
+      <Text>勝者サイド: {winnerSide}</Text>
+      <Text>最終価格: {price}</Text>
+      <Text>報酬: 勝利100コイン / 敗北20コイン</Text>
+      <Button title="ホームへ戻る" onPress={() => router.replace("/")} />
+    </View>
+  );
+}

--- a/apps/mobile/constants/config.ts
+++ b/apps/mobile/constants/config.ts
@@ -1,0 +1,2 @@
+export const API_BASE_URL = "http://localhost:4000/api";
+export const USER_ID = "demo-user";

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "trade-game-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios"
+  },
+  "dependencies": {
+    "expo": "~53.0.10",
+    "expo-router": "~5.1.0",
+    "react": "19.0.0",
+    "react-native": "0.79.2"
+  },
+  "devDependencies": {
+    "typescript": "~5.8.3"
+  }
+}

--- a/apps/mobile/services/api.ts
+++ b/apps/mobile/services/api.ts
@@ -1,0 +1,33 @@
+import { API_BASE_URL, USER_ID } from "../constants/config";
+
+export async function fetchHome() {
+  const res = await fetch(`${API_BASE_URL}/home?userId=${USER_ID}`);
+  return res.json();
+}
+
+export async function claimBonus() {
+  const res = await fetch(`${API_BASE_URL}/login-bonus`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ userId: USER_ID })
+  });
+  return res.json();
+}
+
+export async function startCpuMatch(botLevel: "EASY" | "NORMAL" | "HARD") {
+  const res = await fetch(`${API_BASE_URL}/matches/cpu`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ userId: USER_ID, botLevel })
+  });
+  return res.json();
+}
+
+export async function sendAction(matchId: string, actionType: "BUY" | "SELL" | "HOLD", amount: number) {
+  const res = await fetch(`${API_BASE_URL}/matches/${matchId}/actions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ userId: USER_ID, actionType, amount })
+  });
+  return res.json();
+}

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/trade_game?schema=public"
+PORT=4000

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "trade-game-server",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev",
+    "seed": "tsx prisma/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^6.6.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.7.4",
+    "prisma": "^6.6.0",
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.2"
+  }
+}

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -1,0 +1,173 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum BotLevel {
+  EASY
+  NORMAL
+  HARD
+}
+
+enum MatchType {
+  CPU
+  PVP
+}
+
+enum MatchStatus {
+  WAITING
+  ACTIVE
+  FINISHED
+}
+
+enum Side {
+  BUY
+  SELL
+}
+
+enum ActionType {
+  BUY
+  SELL
+  HOLD
+  ITEM
+}
+
+enum ItemType {
+  PRICE_SPIKE
+  SHIELD
+  DOUBLE_FORCE
+}
+
+enum RewardType {
+  COIN
+  ITEM
+}
+
+model User {
+  id                  String   @id @default(cuid())
+  name                String
+  avatarId            String
+  lifePoints          Int      @default(150)
+  coins               Int      @default(0)
+  lastLoginBonusAt    DateTime?
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+
+  playerStates        MatchPlayerState[]
+  actions             TurnAction[]
+  rewards             Reward[]
+  inventories         UserItem[]
+}
+
+model Avatar {
+  id                  String   @id
+  label               String
+  buyPowerMultiplier  Float    @default(1)
+  sellPowerMultiplier Float    @default(1)
+
+  users               User[]
+}
+
+model Match {
+  id                  String   @id @default(cuid())
+  type                MatchType
+  status              MatchStatus @default(ACTIVE)
+  botLevel            BotLevel?
+  initialPrice        Decimal  @db.Decimal(10, 2)
+  currentPrice        Decimal  @db.Decimal(10, 2)
+  targetUpperPrice    Decimal  @db.Decimal(10, 2)
+  targetLowerPrice    Decimal  @db.Decimal(10, 2)
+  maxTurns            Int
+  turnNumber          Int      @default(1)
+  winnerSide          Side?
+  startedAt           DateTime @default(now())
+  endedAt             DateTime?
+
+  turns               MatchTurn[]
+  players             MatchPlayerState[]
+}
+
+model MatchPlayerState {
+  id                  String   @id @default(cuid())
+  matchId             String
+  userId              String
+  side                Side
+  cash                Int
+  hp                  Int      @default(3)
+  isCpu               Boolean  @default(false)
+
+  match               Match    @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  user                User     @relation(fields: [userId], references: [id])
+
+  @@unique([matchId, side])
+}
+
+model MatchTurn {
+  id                  String   @id @default(cuid())
+  matchId             String
+  turnNumber          Int
+  openPrice           Decimal  @db.Decimal(10, 2)
+  highPrice           Decimal  @db.Decimal(10, 2)
+  lowPrice            Decimal  @db.Decimal(10, 2)
+  closePrice          Decimal  @db.Decimal(10, 2)
+  buyTotal            Int
+  sellTotal           Int
+  createdAt           DateTime @default(now())
+
+  match               Match    @relation(fields: [matchId], references: [id], onDelete: Cascade)
+  actions             TurnAction[]
+
+  @@unique([matchId, turnNumber])
+}
+
+model TurnAction {
+  id                  String   @id @default(cuid())
+  matchTurnId         String
+  userId              String
+  actionType          ActionType
+  amount              Int      @default(0)
+  itemType            ItemType?
+  createdAt           DateTime @default(now())
+
+  matchTurn           MatchTurn @relation(fields: [matchTurnId], references: [id], onDelete: Cascade)
+  user                User      @relation(fields: [userId], references: [id])
+}
+
+model Item {
+  id                  String   @id
+  itemType            ItemType @unique
+  label               String
+  description         String
+  powerValue          Int
+
+  userItems           UserItem[]
+}
+
+model UserItem {
+  id                  String   @id @default(cuid())
+  userId              String
+  itemId              String
+  quantity            Int      @default(0)
+
+  user                User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  item                Item     @relation(fields: [itemId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, itemId])
+}
+
+model Reward {
+  id                  String   @id @default(cuid())
+  userId              String
+  matchId             String?
+  rewardType          RewardType
+  coinAmount          Int      @default(0)
+  itemId              String?
+  quantity            Int      @default(0)
+  createdAt           DateTime @default(now())
+
+  user                User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}

--- a/apps/server/prisma/seed.ts
+++ b/apps/server/prisma/seed.ts
@@ -1,0 +1,65 @@
+import { PrismaClient, ItemType } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  await prisma.avatar.createMany({
+    data: [
+      { id: "balanced", label: "Balanced", buyPowerMultiplier: 1.0, sellPowerMultiplier: 1.0 },
+      { id: "bull", label: "Bull", buyPowerMultiplier: 1.1, sellPowerMultiplier: 0.95 },
+      { id: "bear", label: "Bear", buyPowerMultiplier: 0.95, sellPowerMultiplier: 1.1 }
+    ],
+    skipDuplicates: true
+  });
+
+  await prisma.item.createMany({
+    data: [
+      {
+        id: "price_spike",
+        itemType: ItemType.PRICE_SPIKE,
+        label: "Price Spike",
+        description: "目標価格の1歩手前まで価格を動かす",
+        powerValue: 1
+      },
+      {
+        id: "shield",
+        itemType: ItemType.SHIELD,
+        label: "Shield",
+        description: "次ターンの相手影響を半減",
+        powerValue: 50
+      },
+      {
+        id: "double_force",
+        itemType: ItemType.DOUBLE_FORCE,
+        label: "Double Force",
+        description: "次のBuy/Sellの影響を2倍",
+        powerValue: 2
+      }
+    ],
+    skipDuplicates: true
+  });
+
+  const user = await prisma.user.upsert({
+    where: { id: "demo-user" },
+    update: {},
+    create: { id: "demo-user", name: "Demo Player", avatarId: "balanced", lifePoints: 300, coins: 100 }
+  });
+
+  for (const itemId of ["price_spike", "shield", "double_force"]) {
+    await prisma.userItem.upsert({
+      where: { userId_itemId: { userId: user.id, itemId } },
+      update: { quantity: 3 },
+      create: { userId: user.id, itemId, quantity: 3 }
+    });
+  }
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,0 +1,15 @@
+import cors from "cors";
+import express from "express";
+import gameRoutes from "./routes/gameRoutes";
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.use("/api", gameRoutes);
+
+export default app;

--- a/apps/server/src/config/gameConfig.ts
+++ b/apps/server/src/config/gameConfig.ts
@@ -1,0 +1,17 @@
+export const GAME_CONFIG = {
+  initialCash: 1000,
+  initialPrice: 100,
+  upperTarget: 110,
+  lowerTarget: 90,
+  maxTurns: 10,
+  maxInvestmentPerTurn: 300,
+  matchCostLifePoints: 30,
+  loginBonusLifePoints: 150,
+  basePriceImpactFactor: 0.02,
+  minimumPrice: 1
+} as const;
+
+export const REWARDS = {
+  winCoins: 100,
+  loseCoins: 20
+} as const;

--- a/apps/server/src/controllers/gameController.ts
+++ b/apps/server/src/controllers/gameController.ts
@@ -1,0 +1,65 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+import { claimLoginBonus, getMatch, getUserHome, resolveTurn, startCpuMatch } from "../services/gameService";
+
+const startMatchSchema = z.object({
+  userId: z.string(),
+  botLevel: z.enum(["EASY", "NORMAL", "HARD"])
+});
+
+const actionSchema = z.object({
+  userId: z.string(),
+  actionType: z.enum(["BUY", "SELL", "HOLD", "ITEM"]),
+  amount: z.number().int().min(0).optional(),
+  itemType: z.enum(["PRICE_SPIKE", "SHIELD", "DOUBLE_FORCE"]).optional()
+});
+
+export async function home(req: Request, res: Response) {
+  try {
+    const userId = String(req.query.userId ?? "demo-user");
+    const user = await getUserHome(userId);
+    res.json({ user });
+  } catch (e) {
+    res.status(400).json({ message: (e as Error).message });
+  }
+}
+
+export async function loginBonus(req: Request, res: Response) {
+  try {
+    const parsed = z.object({ userId: z.string() }).parse(req.body);
+    const user = await claimLoginBonus(parsed.userId);
+    res.json({ user });
+  } catch (e) {
+    res.status(400).json({ message: (e as Error).message });
+  }
+}
+
+export async function startCpu(req: Request, res: Response) {
+  try {
+    const parsed = startMatchSchema.parse(req.body);
+    const match = await startCpuMatch(parsed);
+    res.status(201).json({ match });
+  } catch (e) {
+    res.status(400).json({ message: (e as Error).message });
+  }
+}
+
+export async function action(req: Request, res: Response) {
+  try {
+    const matchId = req.params.matchId;
+    const parsed = actionSchema.parse(req.body);
+    const result = await resolveTurn({ matchId, action: parsed });
+    res.json(result);
+  } catch (e) {
+    res.status(400).json({ message: (e as Error).message });
+  }
+}
+
+export async function matchDetail(req: Request, res: Response) {
+  try {
+    const match = await getMatch(req.params.matchId);
+    res.json({ match });
+  } catch (e) {
+    res.status(400).json({ message: (e as Error).message });
+  }
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,0 +1,9 @@
+import dotenv from "dotenv";
+import app from "./app";
+
+dotenv.config();
+
+const port = Number(process.env.PORT ?? 4000);
+app.listen(port, () => {
+  console.log(`server started on :${port}`);
+});

--- a/apps/server/src/routes/gameRoutes.ts
+++ b/apps/server/src/routes/gameRoutes.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { action, home, loginBonus, matchDetail, startCpu } from "../controllers/gameController";
+
+const router = Router();
+
+router.get("/home", home);
+router.post("/login-bonus", loginBonus);
+router.post("/matches/cpu", startCpu);
+router.get("/matches/:matchId", matchDetail);
+router.post("/matches/:matchId/actions", action);
+
+export default router;

--- a/apps/server/src/services/gameService.ts
+++ b/apps/server/src/services/gameService.ts
@@ -1,0 +1,212 @@
+import {
+  ActionType,
+  BotLevel,
+  ItemType,
+  MatchStatus,
+  MatchType,
+  PrismaClient,
+  Side
+} from "@prisma/client";
+import { GAME_CONFIG, REWARDS } from "../config/gameConfig";
+import { ResolveTurnInput, StartCpuMatchInput } from "../types/game";
+
+const prisma = new PrismaClient();
+
+const levelMultiplier: Record<BotLevel, number> = {
+  EASY: 0.7,
+  NORMAL: 1,
+  HARD: 1.2
+};
+
+function clamp(v: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, v));
+}
+
+export async function claimLoginBonus(userId: string) {
+  const now = new Date();
+  const user = await prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new Error("USER_NOT_FOUND");
+
+  const alreadyClaimedToday =
+    user.lastLoginBonusAt && user.lastLoginBonusAt.toDateString() === now.toDateString();
+
+  if (alreadyClaimedToday) {
+    return user;
+  }
+
+  return prisma.user.update({
+    where: { id: userId },
+    data: {
+      lifePoints: { increment: GAME_CONFIG.loginBonusLifePoints },
+      lastLoginBonusAt: now
+    }
+  });
+}
+
+export async function startCpuMatch(input: StartCpuMatchInput) {
+  const user = await prisma.user.findUnique({ where: { id: input.userId } });
+  if (!user) throw new Error("USER_NOT_FOUND");
+  if (user.lifePoints < GAME_CONFIG.matchCostLifePoints) throw new Error("NOT_ENOUGH_LIFE_POINTS");
+
+  const cpuUser = await prisma.user.upsert({
+    where: { id: `cpu-${input.botLevel.toLowerCase()}` },
+    update: {},
+    create: {
+      id: `cpu-${input.botLevel.toLowerCase()}`,
+      name: `CPU ${input.botLevel}`,
+      avatarId: "balanced",
+      lifePoints: 9999
+    }
+  });
+
+  await prisma.user.update({
+    where: { id: user.id },
+    data: { lifePoints: { decrement: GAME_CONFIG.matchCostLifePoints } }
+  });
+
+  return prisma.match.create({
+    data: {
+      type: MatchType.CPU,
+      botLevel: input.botLevel,
+      status: MatchStatus.ACTIVE,
+      initialPrice: GAME_CONFIG.initialPrice,
+      currentPrice: GAME_CONFIG.initialPrice,
+      targetUpperPrice: GAME_CONFIG.upperTarget,
+      targetLowerPrice: GAME_CONFIG.lowerTarget,
+      maxTurns: GAME_CONFIG.maxTurns,
+      players: {
+        create: [
+          { userId: user.id, side: Side.BUY, cash: GAME_CONFIG.initialCash },
+          { userId: cpuUser.id, side: Side.SELL, cash: GAME_CONFIG.initialCash, isCpu: true }
+        ]
+      }
+    },
+    include: { players: true }
+  });
+}
+
+function cpuDecision(botLevel: BotLevel, turn: number) {
+  const base = Math.min(GAME_CONFIG.maxInvestmentPerTurn, 80 + turn * 10);
+  const amount = Math.round(base * levelMultiplier[botLevel]);
+  return { actionType: ActionType.SELL, amount };
+}
+
+function applyItemPrice(itemType: ItemType | undefined, currentPrice: number, side: Side) {
+  if (!itemType) return currentPrice;
+  if (itemType === ItemType.PRICE_SPIKE) {
+    return side === Side.BUY ? GAME_CONFIG.upperTarget - 1 : GAME_CONFIG.lowerTarget + 1;
+  }
+  return currentPrice;
+}
+
+export async function resolveTurn(input: ResolveTurnInput) {
+  const match = await prisma.match.findUnique({
+    where: { id: input.matchId },
+    include: { players: true }
+  });
+  if (!match) throw new Error("MATCH_NOT_FOUND");
+  if (match.status !== MatchStatus.ACTIVE) throw new Error("MATCH_NOT_ACTIVE");
+
+  const player = match.players.find((p) => p.userId === input.action.userId);
+  const cpu = match.players.find((p) => p.isCpu);
+  if (!player || !cpu) throw new Error("PLAYER_NOT_FOUND");
+
+  const playerAmount = clamp(input.action.amount ?? 0, 0, GAME_CONFIG.maxInvestmentPerTurn);
+  const botMove = cpuDecision(match.botLevel ?? BotLevel.EASY, match.turnNumber);
+
+  const buyTotal =
+    (input.action.actionType === ActionType.BUY ? playerAmount : 0) +
+    (botMove.actionType === ActionType.BUY ? botMove.amount : 0);
+  const sellTotal =
+    (input.action.actionType === ActionType.SELL ? playerAmount : 0) +
+    (botMove.actionType === ActionType.SELL ? botMove.amount : 0);
+
+  const open = Number(match.currentPrice);
+  const rawDelta = (buyTotal - sellTotal) * GAME_CONFIG.basePriceImpactFactor;
+  let close = Math.max(GAME_CONFIG.minimumPrice, open + rawDelta);
+  close = applyItemPrice(input.action.itemType, close, player.side);
+  const high = Math.max(open, close);
+  const low = Math.min(open, close);
+
+  const turn = await prisma.matchTurn.create({
+    data: {
+      matchId: match.id,
+      turnNumber: match.turnNumber,
+      openPrice: open,
+      highPrice: high,
+      lowPrice: low,
+      closePrice: close,
+      buyTotal,
+      sellTotal,
+      actions: {
+        create: [
+          {
+            userId: player.userId,
+            actionType: input.action.actionType,
+            amount: playerAmount,
+            itemType: input.action.itemType
+          },
+          { userId: cpu.userId, actionType: botMove.actionType, amount: botMove.amount }
+        ]
+      }
+    }
+  });
+
+  let status = MatchStatus.ACTIVE;
+  let winnerSide: Side | null = null;
+
+  if (close >= Number(match.targetUpperPrice)) {
+    status = MatchStatus.FINISHED;
+    winnerSide = Side.BUY;
+  } else if (close <= Number(match.targetLowerPrice)) {
+    status = MatchStatus.FINISHED;
+    winnerSide = Side.SELL;
+  } else if (match.turnNumber >= match.maxTurns) {
+    status = MatchStatus.FINISHED;
+    winnerSide = close >= Number(match.initialPrice) ? Side.BUY : Side.SELL;
+  }
+
+  const updated = await prisma.match.update({
+    where: { id: match.id },
+    data: {
+      currentPrice: close,
+      turnNumber: status === MatchStatus.FINISHED ? match.turnNumber : match.turnNumber + 1,
+      status,
+      winnerSide,
+      endedAt: status === MatchStatus.FINISHED ? new Date() : null
+    },
+    include: {
+      players: true,
+      turns: { orderBy: { turnNumber: "asc" } }
+    }
+  });
+
+  if (status === MatchStatus.FINISHED) {
+    const isWin = winnerSide === player.side;
+    await prisma.user.update({
+      where: { id: player.userId },
+      data: { coins: { increment: isWin ? REWARDS.winCoins : REWARDS.loseCoins } }
+    });
+  }
+
+  return { match: updated, turn };
+}
+
+export async function getMatch(matchId: string) {
+  return prisma.match.findUnique({
+    where: { id: matchId },
+    include: {
+      players: { include: { user: true } },
+      turns: { include: { actions: true }, orderBy: { turnNumber: "asc" } }
+    }
+  });
+}
+
+export async function getUserHome(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    include: { inventories: { include: { item: true } } }
+  });
+  if (!user) throw new Error("USER_NOT_FOUND");
+  return user;
+}

--- a/apps/server/src/types/game.ts
+++ b/apps/server/src/types/game.ts
@@ -1,0 +1,24 @@
+import { ActionType, BotLevel, ItemType, Side } from "@prisma/client";
+
+export type StartCpuMatchInput = {
+  userId: string;
+  botLevel: BotLevel;
+};
+
+export type PlayerActionInput = {
+  userId: string;
+  actionType: ActionType;
+  amount?: number;
+  itemType?: ItemType;
+};
+
+export type ResolveTurnInput = {
+  matchId: string;
+  action: PlayerActionInput;
+};
+
+export type CpuAction = {
+  actionType: ActionType;
+  amount: number;
+  side: Side;
+};

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src", "prisma/seed.ts"]
+}

--- a/docs/mvp-design.md
+++ b/docs/mvp-design.md
@@ -1,0 +1,77 @@
+# 対戦型トレードゲーム MVP 設計
+
+## 1. システム構成（MVP）
+- **Mobile App (React Native + Expo)**
+  - ホーム / 対戦 / 結果画面
+  - REST API 呼び出し
+- **Game API (Node.js + TypeScript + Express)**
+  - 対戦作成、ターン処理、勝敗判定、報酬配布
+  - 対戦ロジックはサーバ側で一元管理
+- **DB (PostgreSQL + Prisma)**
+  - ユーザ、対戦、ターン、行動履歴、アイテム在庫、報酬
+
+### 将来拡張ポイント
+- PvP リアルタイム化: WebSocket 導入
+- 団体戦: `Team`, `TeamMember`, `TeamMatch` 追加
+- ランキング: 日次/週次の集計テーブル
+- バランス調整: `GameBalanceConfig` テーブル化
+
+## 2. MVP ゲームパラメータ
+- 初期資金: 1000
+- 初期価格: 100
+- 上側目標価格: 110
+- 下側目標価格: 90
+- 最大ターン数: 10
+- 1ターン投入上限: 300
+- CPU: Easy / Normal / Hard
+- アイテム: 3種類（Price Spike, Shield, Double Force）
+- 1試合消費LP: 30
+- ログインボーナス: 150 LP
+
+## 3. API 一覧（MVP）
+- `GET /api/home?userId=...`
+  - ユーザ情報、ライフ、所持アイテム
+- `POST /api/login-bonus`
+  - 当日未受取なら +150 LP
+- `POST /api/matches/cpu`
+  - CPU戦開始（LP 30消費）
+- `GET /api/matches/:matchId`
+  - 対戦の現状態とローソク足履歴
+- `POST /api/matches/:matchId/actions`
+  - プレイヤー行動送信（Buy/Sell/Hold/Item）
+  - サーバ側で CPU 行動も決定し、価格更新・勝敗判定
+
+## 4. 画面一覧（MVP）
+- **ホーム画面**
+  - ユーザ名 / アバター / LP / ボーナス受取 / 対戦開始
+- **対戦画面**
+  - 価格、目標価格、ターン数、行動ボタン（Buy/Sell/Hold）
+  - MVP では簡易表示（次段階でチャート実装）
+- **結果画面**
+  - 勝敗、最終価格、報酬、再戦導線
+
+## 5. ディレクトリ構成
+```
+apps/
+  mobile/
+    app/
+    services/
+    constants/
+  server/
+    prisma/
+    src/
+      config/
+      controllers/
+      routes/
+      services/
+docs/
+  mvp-design.md
+```
+
+## 6. 実装優先順位
+1. Prisma スキーマ + DB マイグレーション
+2. 対戦開始API + ターン解決ロジック
+3. 勝敗判定・報酬配布・LP消費/付与
+4. Mobile: ホーム → 対戦 → 結果の最短導線
+5. アイテム効果（3種中まず Price Spike 有効化）
+6. PvP マッチング（次フェーズ）


### PR DESCRIPTION
### Motivation
- Provide a runnable MVP for a smartphone 1v1 trade game (CPU-first) with server-side game logic, extensible data model, and a minimal mobile UI to iterate quickly. 
- Centralize game rules and balance parameters on the server so future features (PvP, teams, ranking, more items/avatars) can be added without rewriting core logic. 
- Ship a developer-friendly monorepo structure and docs so the stack (Expo + React Native, Node/TypeScript + Express, PostgreSQL + Prisma) can be bootstrapped locally. 

### Description
- Add a complete `Prisma` schema and a `prisma/seed.ts` to model users, avatars, matches, turns (candles), actions, items, inventories, and rewards, plus enums for `BotLevel`, `MatchType`, `MatchStatus`, `ActionType`, and `ItemType`. 
- Implement a TypeScript Express backend (`apps/server/src`) with `gameService` containing CPU decision logic, turn resolution (buy/sell totals → price delta → candle record), win/draw判定, reward distribution, and endpoints in `controllers`/`routes` for home, login bonus, start CPU match, match detail, and actions. 
- Include game constants in `src/config/gameConfig.ts` for easy tuning (`initialCash`, `initialPrice`, `upperTarget`, `lowerTarget`, `maxTurns`, `maxInvestmentPerTurn`, `matchCostLifePoints`, `loginBonusLifePoints`, `basePriceImpactFactor`, etc.). 
- Add a minimal Expo mobile app skeleton (`apps/mobile`) with Home/Battle/Result screens and a simple API client wired to the server endpoints, plus docs `docs/mvp-design.md` and an updated `README.md` with local startup instructions. 

### Testing
- Attempted package installation in the server (`cd apps/server && npm install`), but it failed due to `npm` registry access returning `403 Forbidden`, so dependency installation and runtime verification could not complete in this environment (failure). 
- No automated unit or integration tests were executed in this run because dependency installation was blocked, so no further automated verification was performed (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4754d2a10832c95c38ff29ff609e2)