### PR TITLE
Rewrite EXPO_PUBLIC_API_BASE_URL using DB port heuristic, log resolution, and add Android testing checklist

### DIFF
--- a/apps/mobile/constants/config.ts
+++ b/apps/mobile/constants/config.ts
@@ -37,16 +37,33 @@ function rewriteLoopbackForRuntime(url: string, lanApiBaseUrl: string | null) {
   }
 }
 
+function rewriteLikelyDbPort(url: string) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.port !== "5432") return { url, source: "env" as const };
+    parsed.port = "4000";
+    parsed.pathname = "/api";
+    return {
+      url: parsed.toString().replace(/\/$/, ""),
+      source: "env-db-port-rewritten-to-api-port" as const
+    };
+  } catch {
+    return { url, source: "env" as const };
+  }
+}
+
 const envApiBaseUrlRaw = normalizeApiBaseUrl(process.env.EXPO_PUBLIC_API_BASE_URL);
 const lanApiBaseUrl = inferLanApiBaseUrlFromExpoHost();
 const platformFallback = Platform.OS === "android" ? "http://10.0.2.2:4000/api" : "http://localhost:4000/api";
 
 const envResolved = envApiBaseUrlRaw ? rewriteLoopbackForRuntime(envApiBaseUrlRaw, lanApiBaseUrl) : null;
+const envPortResolved = envResolved ? rewriteLikelyDbPort(envResolved.url) : null;
 
-export const API_BASE_URL = envResolved?.url ?? lanApiBaseUrl ?? platformFallback;
+export const API_BASE_URL = envPortResolved?.url ?? envResolved?.url ?? lanApiBaseUrl ?? platformFallback;
 export const USER_ID = "demo-user";
 
-export const API_BASE_URL_SOURCE = envResolved?.source
+export const API_BASE_URL_SOURCE = envPortResolved?.source
+  ?? envResolved?.source
   ?? (lanApiBaseUrl
     ? "expo-host"
     : Platform.OS === "android"

--- a/apps/mobile/services/api.ts
+++ b/apps/mobile/services/api.ts
@@ -1,5 +1,5 @@
 import { Platform } from "react-native";
-import { API_BASE_URL, USER_ID } from "../constants/config";
+import { API_BASE_URL, API_BASE_URL_SOURCE, USER_ID } from "../constants/config";
 
 const DEBUG_API_LOG = true;
 
@@ -17,6 +17,13 @@ function apiLog(message: string, payload?: unknown) {
     return;
   }
   console.log(`[API] ${message}`, payload);
+}
+
+apiLog("base_url_resolved", { API_BASE_URL, API_BASE_URL_SOURCE, platform: Platform.OS });
+if (API_BASE_URL_SOURCE === "env-db-port-rewritten-to-api-port") {
+  apiLog("base_url_warning", {
+    message: "EXPO_PUBLIC_API_BASE_URL appears to use DB port 5432. Rewrote to API port 4000."
+  });
 }
 
 async function parseJsonOrThrow(res: Response, traceId: string) {

--- a/docs/android-test-checklist.md
+++ b/docs/android-test-checklist.md
@@ -1,0 +1,130 @@
+# Android実機テスト チェックリスト（Expo）
+
+このドキュメントは `apps/mobile` を Android 実機で検証するときの最短手順と、`NETWORK_ERROR: request failed` が出たときの原因推定・対策をまとめたものです。
+
+## 1. 事前条件
+
+- [ ] Android スマホに **Expo Go** をインストール済み
+- [ ] PC とスマホが同じ Wi-Fi（社内/学校 Wi-Fi の隔離設定がある場合は注意）
+- [ ] VPN / Proxy を一時的に OFF
+
+## 2. サーバ起動チェック
+
+```bash
+cd apps/server
+npm run dev
+```
+
+別ターミナルでヘルスチェック:
+
+```bash
+curl http://localhost:4000/health
+```
+
+- [ ] `{"ok":true}` が返る
+
+## 3. 実機用 API URL 設定
+
+`apps/mobile/.env` を編集:
+
+```env
+EXPO_PUBLIC_API_BASE_URL=http://<PCのLAN_IP>:4000
+```
+
+例:
+
+```env
+EXPO_PUBLIC_API_BASE_URL=http://192.168.0.12:4000
+```
+
+> 実機で `localhost` は使わない（端末自身を指してしまうため）。
+
+## 4. モバイル起動（キャッシュクリア）
+
+```bash
+cd apps/mobile
+npm run start:clear
+```
+
+- [ ] Expo Go 内のスキャナで QR を読む（標準カメラではなく）
+- [ ] 接続できない場合は Expo 接続モードを `Tunnel` に切り替えて再試行
+
+## 5. 依存関係の整合チェック（SDK更新後）
+
+```bash
+cd apps/mobile
+npm ls react react-dom react-native expo --all
+npx expo-doctor --verbose
+```
+
+- [ ] `invalid` / `ELSPROBLEMS` が出ない
+
+必要に応じて補正:
+
+```bash
+cd apps/mobile
+npx expo install --fix
+npm install
+```
+
+## 6. `NETWORK_ERROR: request failed` の原因推定と切り分け
+
+`apps/mobile/services/api.ts` は通信失敗時に `NETWORK_ERROR: ... (url=...)` を投げます。まず URL をログで確認してください。
+
+### よくある原因（優先度順）
+
+1. **API の向き先が誤り**
+   - `EXPO_PUBLIC_API_BASE_URL` が `localhost` のまま
+   - PostgreSQL ポート `5432` を指定してしまっている（APIは `4000`）
+   - 端末から到達できない IP / ポートになっている
+
+2. **サーバ未起動 / 起動ポート違い**
+   - `apps/server` が起動していない
+   - `PORT` を変更していて 4000 で待ち受けていない
+
+3. **ネットワーク遮断**
+   - PC 側ファイアウォールが 4000 を遮断
+   - Wi-Fi のクライアント分離で端末→PC が到達不可
+   - VPN / セキュリティソフトの通信制限
+
+4. **キャッシュ残り**
+   - `.env` 修正後に Metro を再起動していない
+
+### 実装仕様ベースの重要ポイント（このプロジェクト固有）
+
+- `EXPO_PUBLIC_API_BASE_URL` が未設定または不正だと、Android は `http://10.0.2.2:4000/api` をフォールバックに使います。これは**エミュレータ向け**なので、実機では到達不能です。
+- `localhost` / `127.0.0.1` が設定されている場合、ランタイムでURL書き換えが走りますが、最終的に実機から到達できるURLになっているかはログで要確認です。
+- API呼び出し時に `[API] ...` ログが出るので、`network_error` ログに含まれる `url=...` がそのまま原因特定の手掛かりになります。
+
+### 症状別の推定原因と対策
+
+| 症状 | 推定原因 | 対策 |
+|---|---|---|
+| `localhost:5432` に届かないエラー | DBポートをAPI URLに設定している | `.env` の `EXPO_PUBLIC_API_BASE_URL` を `http://<PC_IP>:4000` に修正 |
+| どのAPIも即 `NETWORK_ERROR` | URL向き先誤り（`localhost` / `10.0.2.2` / 別IP） | `.env` を PC LAN IP にし、`npm run start:clear` で再起動 |
+| PCの `curl localhost:4000/health` は成功、実機だけ失敗 | 端末→PC通信が遮断 | スマホブラウザで `http://<PC_IP>:4000/health` を確認。失敗ならFW/VPN/Wi-Fi分離を疑う |
+| Expo Goでは起動するがAPIだけ失敗 | `.env`変更が反映されていない | Metro再起動（`start:clear`）と Expo Go 再起動 |
+| ときどき失敗する | ネットワーク品質 / 省電力でWi-Fi切替 | テスト中は同一Wi-Fi固定・省電力OFF・5GHz/2.4GHzの切替抑制 |
+
+### 5分でできる確認手順
+
+1. PC で `curl http://localhost:4000/health` が通るか確認
+2. スマホブラウザで `http://<PCのLAN_IP>:4000/health` を開けるか確認
+3. 開けない場合はネットワーク/ファイアウォール問題
+4. 開けるのにアプリだけ失敗する場合は `.env` と Metro キャッシュを再確認
+5. Metroログの `NETWORK_ERROR ... (url=...)` を確認し、実際に叩いているURLが期待通りか確認
+
+### 追加の実践対策（Android実機向け）
+
+- PCのファイアウォールで TCP `4000` を許可
+- セキュリティソフトのネットワーク保護機能を一時的に無効化して再確認
+- 社内/学校Wi-Fiの場合は `Tunnel` 接続を優先
+- 可能ならサーバ起動を `HOST=0.0.0.0` で固定（環境依存の待受制約を回避）
+- 端末ログで `[API] base_url_resolved` を確認し、`API_BASE_URL` が `:4000/api` になっていることを確認
+
+## 7. 完了条件（Definition of Done）
+
+- [ ] Android 実機でホーム画面が表示される
+- [ ] API 呼び出し時に `NETWORK_ERROR` が発生しない
+- [ ] CPU 戦開始まで進める
+- [ ] 再起動後も同じ手順で再現可能


### PR DESCRIPTION
### Motivation

- Prevent runtime `NETWORK_ERROR` caused by accidentally pointing `EXPO_PUBLIC_API_BASE_URL` at a Postgres DB port (`5432`) instead of the API port (`4000`).
- Surface the resolved base URL and warn when an automated rewrite occurs to aid debugging on Android devices and emulators.
- Provide a short Android real-device test checklist to help diagnose common connectivity issues.

### Description

- Added `rewriteLikelyDbPort` in `apps/mobile/constants/config.ts` to detect `:5432` and rewrite the URL to use port `4000` and path `/api` and expose a source tag for the rewrite.
- Wire the rewrite into resolution logic by introducing `envPortResolved` and preferring it when computing `API_BASE_URL` and `API_BASE_URL_SOURCE`.
- Added logging in `apps/mobile/services/api.ts` to log the resolved base URL (`API_BASE_URL`, `API_BASE_URL_SOURCE`) and emit a warning when a DB port rewrite was applied.
- Added `docs/android-test-checklist.md` (Japanese) with step-by-step verification and troubleshooting guidance for Android real-device testing and common causes of `NETWORK_ERROR`.

### Testing

- Ran TypeScript typecheck (`tsc`) against the workspace and it completed successfully.
- Ran the repository's automated test suite (`npm test`) and existing tests passed without failures.
- Confirmed the new logs compile and integrate with the mobile service code by running the mobile build step (`apps/mobile` build), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf51c9b8c4832c9033d48552e72f76)