### PR TITLE
Move lot/item controls into chart tap panel and consolidate subturn display

### DIFF
--- a/apps/mobile/app/battle.tsx
+++ b/apps/mobile/app/battle.tsx
@@ -305,27 +305,12 @@ export default function BattleScreen() {
     <ScrollView contentContainerStyle={{ gap: 10, padding: 20 }} style={{ flex: 1 }}>
       <Text style={{ fontSize: 20, fontWeight: "700" }}>対戦画面</Text>
       {error ? <Text style={{ color: "red" }}>通信エラー: {error}</Text> : null}
-      <Text style={{ color: "#1d4ed8" }}>{turnInfo}</Text>
+      <Text style={{ color: "#1d4ed8" }}>{`${turnInfo} / ローソク足内バトル ${Number(state?.subturn ?? 1)}/3`}</Text>
       {notice ? <Text style={{ color: "#1d4ed8" }}>{notice}</Text> : null}
       <Text>Match: {matchId}</Text>
       <Text>現在価格: {state?.currentPrice ?? "100"}</Text>
       <Text>ターン: {state?.turnNumber ?? 1}</Text>
-      <Text>ローソク足内バトル: {Number(state?.subturn ?? 1)}/3</Text>
-      <Text>ロット選択（最大 {maxLot}）</Text>
-      <ScrollView horizontal showsHorizontalScrollIndicator style={{ maxHeight: 44 }}>
-        <View style={{ flexDirection: "row", gap: 8 }}>
-          {lotOptions.map((lot) => (
-            <Button key={lot} title={lot === amount ? `●${lot}` : String(lot)} onPress={() => setAmount(lot)} />
-          ))}
-        </View>
-      </ScrollView>
       <Text>BUY合計損益: {pnlBySide.BUY.toFixed(2)} / SELL合計損益: {pnlBySide.SELL.toFixed(2)}</Text>
-      <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
-        <Button title="⚡Price" onPress={() => useItem("PRICE_SPIKE")} />
-        <Button title="🛡Shield" onPress={() => useItem("SHIELD")} />
-        <Button title="💥Force" onPress={() => useItem("DOUBLE_FORCE")} />
-        <Button title="🧹オール決済" onPress={settleAllOpenPositions} />
-      </View>
 
       {state?.status === "FINISHED" ? (
         <Text style={{ fontWeight: "700" }}>
@@ -349,13 +334,27 @@ export default function BattleScreen() {
         }}
       />
       {chartTapPrice !== null ? (
-        <View style={{ borderWidth: 1, borderRadius: 8, padding: 10, gap: 6 }}>
+        <View style={{ borderWidth: 1, borderRadius: 8, padding: 10, gap: 8 }}>
           <Text style={{ fontWeight: "700" }}>チャートタップ操作</Text>
           <Text>タップ価格: {chartTapPrice.toFixed(2)}</Text>
+          <Text>ロット選択（最大 {maxLot}）</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator style={{ maxHeight: 44 }}>
+            <View style={{ flexDirection: "row", gap: 8 }}>
+              {lotOptions.map((lot) => (
+                <Button key={lot} title={lot === amount ? `●${lot}` : String(lot)} onPress={() => setAmount(lot)} />
+              ))}
+            </View>
+          </ScrollView>
           <View style={{ flexDirection: "row", gap: 8 }}>
             <Button title={`Buy ${amount}`} onPress={() => action("BUY")} />
             <Button title={`Sell ${amount}`} onPress={() => action("SELL")} />
             <Button title="Hold" onPress={() => action("HOLD")} />
+          </View>
+          <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+            <Button title="⚡Price" onPress={() => useItem("PRICE_SPIKE")} />
+            <Button title="🛡Shield" onPress={() => useItem("SHIELD")} />
+            <Button title="💥Force" onPress={() => useItem("DOUBLE_FORCE")} />
+            <Button title="🧹オール決済" onPress={settleAllOpenPositions} />
           </View>
         </View>
       ) : null}


### PR DESCRIPTION
### Motivation
- チャート上をタップしたときに操作可能な領域に、ロット選択とアイテム操作を集約することで操作の一貫性を高めるため。 
- `PRICE` / `SHIELD` / `FORCE` / `オール決済` のボタンをチャートタップ操作パネルに移してコンテキスト密度を改善するため。 
- ローソク足内バトルの表示をターン表示と同一行にまとめ、画面の縦スペースと可読性を改善するため。 

### Description
- `apps/mobile/app/battle.tsx` の UI を変更し、常時表示していたロット選択 UI をチャートタップ操作パネル内に移動しました（`chartTapPrice !== null` の境界内に追加）。
- 同ファイル内で `PRICE` / `SHIELD` / `DOUBLE_FORCE` / `オール決済` ボタンをチャートタップ操作パネルへ移動し、パネル内でロット選択→売買→アイテムの操作フローになるよう再配置しました。 
- ターン行表示を編集し、従来別行で表示していたローソク足内バトル情報を `turnInfo` 行に統合して 1 行で表示するように変更しました（`{`${turnInfo} / ローソク足内バトル ${Number(state?.subturn ?? 1)}/3`}`）。
- パネルの余白・ギャップ値を微調整（`padding`/`gap` 値の変更）してレイアウトを整えました。 

### Testing
- 実行済み自動チェック: `npm --prefix apps/mobile run typecheck` を実行しましたが、現環境では `expo/tsconfig.base` や Expo / React Native の型定義が解決できないため型チェックは失敗しました（タイプチェックは環境依存の欠如によりエラーとなりました）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0581a9d7c832caf5116075cb2bab7)