### PR TITLE
Move lot selection into chart-tap UI and improve CPU decision scoring

### DIFF
--- a/apps/mobile/app/battle.tsx
+++ b/apps/mobile/app/battle.tsx
@@ -305,27 +305,12 @@ export default function BattleScreen() {
     <ScrollView contentContainerStyle={{ gap: 10, padding: 20 }} style={{ flex: 1 }}>
       <Text style={{ fontSize: 20, fontWeight: "700" }}>対戦画面</Text>
       {error ? <Text style={{ color: "red" }}>通信エラー: {error}</Text> : null}
-      <Text style={{ color: "#1d4ed8" }}>{turnInfo}</Text>
+      <Text style={{ color: "#1d4ed8" }}>{`${turnInfo} / ローソク足内バトル ${Number(state?.subturn ?? 1)}/3`}</Text>
       {notice ? <Text style={{ color: "#1d4ed8" }}>{notice}</Text> : null}
       <Text>Match: {matchId}</Text>
       <Text>現在価格: {state?.currentPrice ?? "100"}</Text>
       <Text>ターン: {state?.turnNumber ?? 1}</Text>
-      <Text>ローソク足内バトル: {Number(state?.subturn ?? 1)}/3</Text>
-      <Text>ロット選択（最大 {maxLot}）</Text>
-      <ScrollView horizontal showsHorizontalScrollIndicator style={{ maxHeight: 44 }}>
-        <View style={{ flexDirection: "row", gap: 8 }}>
-          {lotOptions.map((lot) => (
-            <Button key={lot} title={lot === amount ? `●${lot}` : String(lot)} onPress={() => setAmount(lot)} />
-          ))}
-        </View>
-      </ScrollView>
       <Text>BUY合計損益: {pnlBySide.BUY.toFixed(2)} / SELL合計損益: {pnlBySide.SELL.toFixed(2)}</Text>
-      <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
-        <Button title="⚡Price" onPress={() => useItem("PRICE_SPIKE")} />
-        <Button title="🛡Shield" onPress={() => useItem("SHIELD")} />
-        <Button title="💥Force" onPress={() => useItem("DOUBLE_FORCE")} />
-        <Button title="🧹オール決済" onPress={settleAllOpenPositions} />
-      </View>
 
       {state?.status === "FINISHED" ? (
         <Text style={{ fontWeight: "700" }}>
@@ -349,13 +334,27 @@ export default function BattleScreen() {
         }}
       />
       {chartTapPrice !== null ? (
-        <View style={{ borderWidth: 1, borderRadius: 8, padding: 10, gap: 6 }}>
+        <View style={{ borderWidth: 1, borderRadius: 8, padding: 10, gap: 8 }}>
           <Text style={{ fontWeight: "700" }}>チャートタップ操作</Text>
           <Text>タップ価格: {chartTapPrice.toFixed(2)}</Text>
+          <Text>ロット選択（最大 {maxLot}）</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator style={{ maxHeight: 44 }}>
+            <View style={{ flexDirection: "row", gap: 8 }}>
+              {lotOptions.map((lot) => (
+                <Button key={lot} title={lot === amount ? `●${lot}` : String(lot)} onPress={() => setAmount(lot)} />
+              ))}
+            </View>
+          </ScrollView>
           <View style={{ flexDirection: "row", gap: 8 }}>
             <Button title={`Buy ${amount}`} onPress={() => action("BUY")} />
             <Button title={`Sell ${amount}`} onPress={() => action("SELL")} />
             <Button title="Hold" onPress={() => action("HOLD")} />
+          </View>
+          <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+            <Button title="⚡Price" onPress={() => useItem("PRICE_SPIKE")} />
+            <Button title="🛡Shield" onPress={() => useItem("SHIELD")} />
+            <Button title="💥Force" onPress={() => useItem("DOUBLE_FORCE")} />
+            <Button title="🧹オール決済" onPress={settleAllOpenPositions} />
           </View>
         </View>
       ) : null}

--- a/apps/server/src/services/cpuStrategy/cpuStrategy.ts
+++ b/apps/server/src/services/cpuStrategy/cpuStrategy.ts
@@ -29,6 +29,10 @@ function decideCoreAction(difficulty: CpuDifficulty, context: BattleContext): Cp
   const patterns = detectPatternsFromPriceHistory(prices);
 
   const momentum = (context.currentPrice - context.initialPrice) / Math.max(1, context.initialPrice);
+  const shortTrend =
+    prices.length >= 2
+      ? (prices[prices.length - 1] - prices[prices.length - 2]) / Math.max(1, prices[prices.length - 2])
+      : 0;
   const patternScore = patterns.reduce((sum, p) => {
     const fakePenalty = difficulty === "hard" && p.isFakeBreakRisk ? CPU_STRATEGY_CONSTANTS.fakeBreakPenalty : 0;
     return sum + (scoreActionByBias(p.pattern.cpuBias) - fakePenalty) * p.confidence;
@@ -38,7 +42,7 @@ function decideCoreAction(difficulty: CpuDifficulty, context: BattleContext): Cp
   const upDistance = Math.abs(context.targetUpPrice - context.currentPrice);
   const downDistance = Math.abs(context.currentPrice - context.targetDownPrice);
 
-  let directionalScore = patternScore + momentum * 2;
+  let directionalScore = patternScore + momentum * 5 + shortTrend * 7;
 
   if (difficulty === "hard") {
     if (turnsLeft <= 2) {
@@ -62,16 +66,30 @@ function decideCoreAction(difficulty: CpuDifficulty, context: BattleContext): Cp
     };
   }
 
-  if (directionalScore > 0.2) {
+  const directionalThreshold = difficulty === "easy" ? 0.06 : difficulty === "normal" ? 0.045 : 0.03;
+
+  if (directionalScore > directionalThreshold) {
     return { action: "buy", amount: baseAmount, reason: `bullish_score_${directionalScore.toFixed(2)}` };
   }
 
-  if (directionalScore < -0.2) {
+  if (directionalScore < -directionalThreshold) {
     return { action: "sell", amount: baseAmount, reason: `bearish_score_${directionalScore.toFixed(2)}` };
   }
 
-  const conservative = difficulty === "hard" ? Math.round(baseAmount * 0.6) : Math.round(baseAmount * 0.45);
-  return { action: "hold", amount: conservative, reason: `neutral_score_${directionalScore.toFixed(2)}` };
+  const neutralTradeChance = difficulty === "easy" ? 0.22 : difficulty === "normal" ? 0.38 : 0.55;
+  if (Math.random() < neutralTradeChance) {
+    const fallbackBias = momentum + shortTrend;
+    const action = fallbackBias >= 0 ? "buy" : "sell";
+    const conservativeAmount = difficulty === "hard" ? Math.round(baseAmount * 0.7) : Math.round(baseAmount * 0.5);
+    return {
+      action,
+      amount: clamp(conservativeAmount, CPU_STRATEGY_CONSTANTS.minTradeAmount, CPU_STRATEGY_CONSTANTS.maxTradeAmount),
+      reason: `neutral_follow_${fallbackBias.toFixed(3)}`
+    };
+  }
+
+  const conservative = difficulty === "hard" ? Math.round(baseAmount * 0.55) : Math.round(baseAmount * 0.4);
+  return { action: "hold", amount: conservative, reason: `neutral_hold_${directionalScore.toFixed(2)}` };
 }
 
 export function decideCpuAction(difficulty: CpuDifficulty, context: BattleContext): CpuDecision {


### PR DESCRIPTION
### Motivation
- Improve mobile UX by surfacing trade controls only when the user taps the chart and show subturn info inline. 
- Make CPU actions more responsive to very short-term price changes and difficulty level so AI behaviors feel more varied and realistic.

### Description
- Updated the battle screen to append subturn info to the `turnInfo` line and relocate lot selection, amount buttons, and item/settle controls into the chart tap panel so controls appear only when `chartTapPrice` is set. 
- Adjusted spacing in the chart tap panel by changing the container gap from `6` to `8`. 
- Kept `settleAllOpenPositions` behavior but moved its button into the chart-tap UI. 
- Enhanced CPU strategy in `decideCoreAction` by adding a `shortTrend` delta, increasing momentum/short-trend weighting, and combining pattern score into a new `directionalScore`. 
- Introduced difficulty-dependent decision thresholds (`directionalThreshold`) and a `neutralTradeChance` fallback that sometimes makes conservative buy/sell trades based on short-term bias, with amounts clamped via `CPU_STRATEGY_CONSTANTS`. 
- Tweaked conservative/hold amount multipliers and adjusted reason strings for clarity in returned `CpuDecision` objects.

### Testing
- Ran TypeScript type check with `yarn tsc` and the project compiled without type errors. 
- Executed server unit tests with `yarn test` and all tests passed. 
- Performed a basic mobile build and smoke-tested the `BattleScreen` UI to confirm the chart-tap controls and relocated buttons render and the subturn text displays as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0581a9d7c832caf5116075cb2bab7)