### PR TITLE
Improve CPU trading logic, add CPU decision audit logs, and refine mobile trading UI

### DIFF
--- a/apps/mobile/app/battle.tsx
+++ b/apps/mobile/app/battle.tsx
@@ -309,23 +309,10 @@ export default function BattleScreen() {
       {notice ? <Text style={{ color: "#1d4ed8" }}>{notice}</Text> : null}
       <Text>Match: {matchId}</Text>
       <Text>現在価格: {state?.currentPrice ?? "100"}</Text>
-      <Text>ターン: {state?.turnNumber ?? 1}</Text>
-      <Text>ローソク足内バトル: {Number(state?.subturn ?? 1)}/3</Text>
-      <Text>ロット選択（最大 {maxLot}）</Text>
-      <ScrollView horizontal showsHorizontalScrollIndicator style={{ maxHeight: 44 }}>
-        <View style={{ flexDirection: "row", gap: 8 }}>
-          {lotOptions.map((lot) => (
-            <Button key={lot} title={lot === amount ? `●${lot}` : String(lot)} onPress={() => setAmount(lot)} />
-          ))}
-        </View>
-      </ScrollView>
+      <Text>
+        ターン: {state?.turnNumber ?? 1}（ローソク足内バトル {Number(state?.subturn ?? 1)}/3）
+      </Text>
       <Text>BUY合計損益: {pnlBySide.BUY.toFixed(2)} / SELL合計損益: {pnlBySide.SELL.toFixed(2)}</Text>
-      <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
-        <Button title="⚡Price" onPress={() => useItem("PRICE_SPIKE")} />
-        <Button title="🛡Shield" onPress={() => useItem("SHIELD")} />
-        <Button title="💥Force" onPress={() => useItem("DOUBLE_FORCE")} />
-        <Button title="🧹オール決済" onPress={settleAllOpenPositions} />
-      </View>
 
       {state?.status === "FINISHED" ? (
         <Text style={{ fontWeight: "700" }}>
@@ -349,13 +336,27 @@ export default function BattleScreen() {
         }}
       />
       {chartTapPrice !== null ? (
-        <View style={{ borderWidth: 1, borderRadius: 8, padding: 10, gap: 6 }}>
+        <View style={{ borderWidth: 1, borderRadius: 8, padding: 10, gap: 8 }}>
           <Text style={{ fontWeight: "700" }}>チャートタップ操作</Text>
           <Text>タップ価格: {chartTapPrice.toFixed(2)}</Text>
+          <Text>ロット選択（最大 {maxLot}）</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator style={{ maxHeight: 44 }}>
+            <View style={{ flexDirection: "row", gap: 8 }}>
+              {lotOptions.map((lot) => (
+                <Button key={lot} title={lot === amount ? `●${lot}` : String(lot)} onPress={() => setAmount(lot)} />
+              ))}
+            </View>
+          </ScrollView>
           <View style={{ flexDirection: "row", gap: 8 }}>
             <Button title={`Buy ${amount}`} onPress={() => action("BUY")} />
             <Button title={`Sell ${amount}`} onPress={() => action("SELL")} />
             <Button title="Hold" onPress={() => action("HOLD")} />
+          </View>
+          <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+            <Button title="⚡" onPress={() => useItem("PRICE_SPIKE")} />
+            <Button title="🛡" onPress={() => useItem("SHIELD")} />
+            <Button title="💥" onPress={() => useItem("DOUBLE_FORCE")} />
+            <Button title="🧹" onPress={settleAllOpenPositions} />
           </View>
         </View>
       ) : null}

--- a/apps/server/src/services/cpuStrategy/cpuStrategy.ts
+++ b/apps/server/src/services/cpuStrategy/cpuStrategy.ts
@@ -29,6 +29,10 @@ function decideCoreAction(difficulty: CpuDifficulty, context: BattleContext): Cp
   const patterns = detectPatternsFromPriceHistory(prices);
 
   const momentum = (context.currentPrice - context.initialPrice) / Math.max(1, context.initialPrice);
+  const shortTrend =
+    prices.length >= 2
+      ? (prices[prices.length - 1] - prices[prices.length - 2]) / Math.max(1, prices[prices.length - 2])
+      : 0;
   const patternScore = patterns.reduce((sum, p) => {
     const fakePenalty = difficulty === "hard" && p.isFakeBreakRisk ? CPU_STRATEGY_CONSTANTS.fakeBreakPenalty : 0;
     return sum + (scoreActionByBias(p.pattern.cpuBias) - fakePenalty) * p.confidence;
@@ -38,7 +42,7 @@ function decideCoreAction(difficulty: CpuDifficulty, context: BattleContext): Cp
   const upDistance = Math.abs(context.targetUpPrice - context.currentPrice);
   const downDistance = Math.abs(context.currentPrice - context.targetDownPrice);
 
-  let directionalScore = patternScore + momentum * 2;
+  let directionalScore = patternScore + momentum * 5 + shortTrend * 7;
 
   if (difficulty === "hard") {
     if (turnsLeft <= 2) {
@@ -58,20 +62,46 @@ function decideCoreAction(difficulty: CpuDifficulty, context: BattleContext): Cp
       action: "item",
       amount: 0,
       itemId: "PRICE_SPIKE",
-      reason: `item_finisher_${difficulty}`
+      reason: `item_finisher_${difficulty}_turnsLeft=${turnsLeft}`
     };
   }
 
-  if (directionalScore > 0.2) {
-    return { action: "buy", amount: baseAmount, reason: `bullish_score_${directionalScore.toFixed(2)}` };
+  const directionalThreshold = difficulty === "easy" ? 0.06 : difficulty === "normal" ? 0.045 : 0.03;
+
+  if (directionalScore > directionalThreshold) {
+    return {
+      action: "buy",
+      amount: baseAmount,
+      reason: `bullish_ds=${directionalScore.toFixed(3)}_th=${directionalThreshold.toFixed(3)}`
+    };
   }
 
-  if (directionalScore < -0.2) {
-    return { action: "sell", amount: baseAmount, reason: `bearish_score_${directionalScore.toFixed(2)}` };
+  if (directionalScore < -directionalThreshold) {
+    return {
+      action: "sell",
+      amount: baseAmount,
+      reason: `bearish_ds=${directionalScore.toFixed(3)}_th=${directionalThreshold.toFixed(3)}`
+    };
   }
 
-  const conservative = difficulty === "hard" ? Math.round(baseAmount * 0.6) : Math.round(baseAmount * 0.45);
-  return { action: "hold", amount: conservative, reason: `neutral_score_${directionalScore.toFixed(2)}` };
+  const neutralTradeChance = difficulty === "easy" ? 0.22 : difficulty === "normal" ? 0.38 : 0.55;
+  if (Math.random() < neutralTradeChance) {
+    const fallbackBias = momentum + shortTrend;
+    const action = fallbackBias >= 0 ? "buy" : "sell";
+    const conservativeAmount = difficulty === "hard" ? Math.round(baseAmount * 0.7) : Math.round(baseAmount * 0.5);
+    return {
+      action,
+      amount: clamp(conservativeAmount, CPU_STRATEGY_CONSTANTS.minTradeAmount, CPU_STRATEGY_CONSTANTS.maxTradeAmount),
+      reason: `neutral_follow_bias=${fallbackBias.toFixed(3)}_ds=${directionalScore.toFixed(3)}`
+    };
+  }
+
+  const conservative = difficulty === "hard" ? Math.round(baseAmount * 0.55) : Math.round(baseAmount * 0.4);
+  return {
+    action: "hold",
+    amount: conservative,
+    reason: `neutral_hold_ds=${directionalScore.toFixed(3)}_th=${directionalThreshold.toFixed(3)}`
+  };
 }
 
 export function decideCpuAction(difficulty: CpuDifficulty, context: BattleContext): CpuDecision {

--- a/apps/server/src/services/gameService.ts
+++ b/apps/server/src/services/gameService.ts
@@ -183,6 +183,19 @@ export async function resolveTurn(input: ResolveTurnInput) {
     amount: clamp(cpuDecision.amount, 0, GAME_CONFIG.maxInvestmentPerTurn),
     itemType: cpuDecision.itemId === "PRICE_SPIKE" ? ItemType.PRICE_SPIKE : undefined
   };
+  auditLog("CPU_DECISION_EVALUATED", {
+    matchId: match.id,
+    turnNumber: match.turnNumber,
+    subturnBeforeResolve: (matchSubturnCounts.get(match.id) ?? 0) + 1,
+    cpuAction: cpuDecision.action,
+    cpuAmountRequested: cpuDecision.amount,
+    cpuAmountApplied: botMove.amount,
+    cpuItem: cpuDecision.itemId ?? null,
+    cpuReason: cpuDecision.reason,
+    currentPrice: battleContext.currentPrice,
+    initialPrice: battleContext.initialPrice,
+    priceHistoryCount: battleContext.priceHistory.length
+  });
 
   const effectState = matchEffects.get(match.id) ?? { shieldUntilTurn: {}, doubleForceUntilTurn: {} };
   const playerDoubleForce = effectState.doubleForceUntilTurn[player.side] === match.turnNumber ? 2 : 1;
@@ -357,6 +370,10 @@ export async function resolveTurn(input: ResolveTurnInput) {
     turnNumber: match.turnNumber,
     subturn: currentSubturn,
     actionType: input.action.actionType,
+    playerAmount: playerEffectiveAmount,
+    cpuActionType: botMove.actionType,
+    cpuAmount: cpuEffectiveAmount,
+    cpuReason: cpuDecision.reason,
     buyTotal,
     sellTotal,
     close


### PR DESCRIPTION
### Motivation
- Improve CPU trading behavior to be more responsive to short-term trend and reduce brittle thresholding across difficulties.
- Surface more focused trading controls in the mobile chart tap UI and simplify the main battle view.
- Add audit logging for CPU decisions to help diagnose and analyze bot behavior during turns.

### Description
- CPU strategy: introduce `shortTrend` and increase influence of `momentum` and `shortTrend` in directional scoring, add per-difficulty `directionalThreshold`, a `neutralTradeChance` fallback that can open conservative trades, and adjust conservative/hold amounts and reason strings for clearer telemetry. 
- Server game service: emit an `auditLog("CPU_DECISION_EVALUATED", ...)` record with CPU decision details and enrich the `TURN_RESOLVED` audit with `playerAmount`, `cpuActionType`, `cpuAmount`, and `cpuReason` for each resolved turn. 
- Mobile client UI: merge turn/subturn into one line, move lot selection and item/action buttons into the chart-tap panel, adjust spacing (`gap`), and update button labels to a compact emoji presentation when in the tap panel.

### Testing
- Ran server unit tests with `pnpm --filter apps/server test` and they completed successfully.
- Built the mobile app TypeScript/JS bundle with `pnpm --filter apps/mobile build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0581a9d7c832caf5116075cb2bab7)