### PR TITLE
Configurable victory condition, improved CPU strategy, and battle UI tweaks

### DIFF
--- a/apps/mobile/app/battle.tsx
+++ b/apps/mobile/app/battle.tsx
@@ -307,30 +307,14 @@ export default function BattleScreen() {
       {error ? <Text style={{ color: "red" }}>通信エラー: {error}</Text> : null}
       <Text style={{ color: "#1d4ed8" }}>{turnInfo}</Text>
       {notice ? <Text style={{ color: "#1d4ed8" }}>{notice}</Text> : null}
-      <Text>Match: {matchId}</Text>
       <Text>現在価格: {state?.currentPrice ?? "100"}</Text>
-      <Text>ターン: {state?.turnNumber ?? 1}</Text>
-      <Text>ローソク足内バトル: {Number(state?.subturn ?? 1)}/3</Text>
-      <Text>ロット選択（最大 {maxLot}）</Text>
-      <ScrollView horizontal showsHorizontalScrollIndicator style={{ maxHeight: 44 }}>
-        <View style={{ flexDirection: "row", gap: 8 }}>
-          {lotOptions.map((lot) => (
-            <Button key={lot} title={lot === amount ? `●${lot}` : String(lot)} onPress={() => setAmount(lot)} />
-          ))}
-        </View>
-      </ScrollView>
+      <Text>
+        ターン: {state?.turnNumber ?? 1}（ローソク足内バトル {Number(state?.subturn ?? 1)}/3）
+      </Text>
       <Text>BUY合計損益: {pnlBySide.BUY.toFixed(2)} / SELL合計損益: {pnlBySide.SELL.toFixed(2)}</Text>
-      <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
-        <Button title="⚡Price" onPress={() => useItem("PRICE_SPIKE")} />
-        <Button title="🛡Shield" onPress={() => useItem("SHIELD")} />
-        <Button title="💥Force" onPress={() => useItem("DOUBLE_FORCE")} />
-        <Button title="🧹オール決済" onPress={settleAllOpenPositions} />
-      </View>
 
       {state?.status === "FINISHED" ? (
-        <Text style={{ fontWeight: "700" }}>
-          損益勝者: {pnlBySide.BUY === pnlBySide.SELL ? "DRAW" : pnlBySide.BUY > pnlBySide.SELL ? "BUY" : "SELL"}
-        </Text>
+        <Text style={{ fontWeight: "700" }}>損益勝者: {selfPnl >= opponentPnl ? "自分" : "相手"}</Text>
       ) : null}
       <Text>
         自分: {AVATAR_PRESETS[selfPlayer?.userId ?? "demo-user"] ?? "🙂"} 損益={selfPnl.toFixed(2)} {selfResultLabel} / 相手:{" "}
@@ -349,13 +333,27 @@ export default function BattleScreen() {
         }}
       />
       {chartTapPrice !== null ? (
-        <View style={{ borderWidth: 1, borderRadius: 8, padding: 10, gap: 6 }}>
+        <View style={{ borderWidth: 1, borderRadius: 8, padding: 10, gap: 8 }}>
           <Text style={{ fontWeight: "700" }}>チャートタップ操作</Text>
           <Text>タップ価格: {chartTapPrice.toFixed(2)}</Text>
+          <Text>ロット選択（最大 {maxLot}）</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator style={{ maxHeight: 44 }}>
+            <View style={{ flexDirection: "row", gap: 8 }}>
+              {lotOptions.map((lot) => (
+                <Button key={lot} title={lot === amount ? `●${lot}` : String(lot)} onPress={() => setAmount(lot)} />
+              ))}
+            </View>
+          </ScrollView>
           <View style={{ flexDirection: "row", gap: 8 }}>
             <Button title={`Buy ${amount}`} onPress={() => action("BUY")} />
             <Button title={`Sell ${amount}`} onPress={() => action("SELL")} />
             <Button title="Hold" onPress={() => action("HOLD")} />
+          </View>
+          <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
+            <Button title="⚡" onPress={() => useItem("PRICE_SPIKE")} />
+            <Button title="🛡" onPress={() => useItem("SHIELD")} />
+            <Button title="💥" onPress={() => useItem("DOUBLE_FORCE")} />
+            <Button title="🧹" onPress={settleAllOpenPositions} />
           </View>
         </View>
       ) : null}
@@ -428,6 +426,7 @@ export default function BattleScreen() {
         ))}
       </View>
       <View style={{ borderTopWidth: 1, borderColor: "#cbd5e1", paddingTop: 8, marginTop: 8 }}>
+        <Text style={{ fontSize: 12, color: "#64748b" }}>Match: {matchId}</Text>
         <Text style={{ fontSize: 12, color: "#64748b" }}>API: {API_BASE_URL}</Text>
         <Text style={{ fontSize: 12, color: "#64748b" }}>API Source: {API_BASE_URL_SOURCE}</Text>
         <Text style={{ fontSize: 12, color: "#64748b" }}>UI Revision: {UI_REVISION}</Text>

--- a/apps/server/src/config/gameConfig.ts
+++ b/apps/server/src/config/gameConfig.ts
@@ -1,3 +1,8 @@
+export type VictoryConditionMode = "TARGET_REACH" | "PNL_BATTLE";
+
+const configuredVictoryCondition =
+  process.env.GAME_VICTORY_CONDITION === "TARGET_REACH" ? "TARGET_REACH" : "PNL_BATTLE";
+
 export const GAME_CONFIG = {
   initialCash: 1000,
   initialPrice: 100,
@@ -10,7 +15,8 @@ export const GAME_CONFIG = {
   debugRefillLifePoints: 300,
   debugMinLifePoints: 90,
   basePriceImpactFactor: 0.02,
-  minimumPrice: 1
+  minimumPrice: 1,
+  victoryConditionMode: configuredVictoryCondition as VictoryConditionMode
 } as const;
 
 export const REWARDS = {

--- a/apps/server/src/services/cpuStrategy/cpuStrategy.ts
+++ b/apps/server/src/services/cpuStrategy/cpuStrategy.ts
@@ -29,6 +29,10 @@ function decideCoreAction(difficulty: CpuDifficulty, context: BattleContext): Cp
   const patterns = detectPatternsFromPriceHistory(prices);
 
   const momentum = (context.currentPrice - context.initialPrice) / Math.max(1, context.initialPrice);
+  const shortTrend =
+    prices.length >= 2
+      ? (prices[prices.length - 1] - prices[prices.length - 2]) / Math.max(1, prices[prices.length - 2])
+      : 0;
   const patternScore = patterns.reduce((sum, p) => {
     const fakePenalty = difficulty === "hard" && p.isFakeBreakRisk ? CPU_STRATEGY_CONSTANTS.fakeBreakPenalty : 0;
     return sum + (scoreActionByBias(p.pattern.cpuBias) - fakePenalty) * p.confidence;
@@ -38,7 +42,7 @@ function decideCoreAction(difficulty: CpuDifficulty, context: BattleContext): Cp
   const upDistance = Math.abs(context.targetUpPrice - context.currentPrice);
   const downDistance = Math.abs(context.currentPrice - context.targetDownPrice);
 
-  let directionalScore = patternScore + momentum * 2;
+  let directionalScore = patternScore + momentum * 5 + shortTrend * 7;
 
   if (difficulty === "hard") {
     if (turnsLeft <= 2) {
@@ -58,20 +62,46 @@ function decideCoreAction(difficulty: CpuDifficulty, context: BattleContext): Cp
       action: "item",
       amount: 0,
       itemId: "PRICE_SPIKE",
-      reason: `item_finisher_${difficulty}`
+      reason: `item_finisher_${difficulty}_turnsLeft=${turnsLeft}`
     };
   }
 
-  if (directionalScore > 0.2) {
-    return { action: "buy", amount: baseAmount, reason: `bullish_score_${directionalScore.toFixed(2)}` };
+  const directionalThreshold = difficulty === "easy" ? 0.06 : difficulty === "normal" ? 0.045 : 0.03;
+
+  if (directionalScore > directionalThreshold) {
+    return {
+      action: "buy",
+      amount: baseAmount,
+      reason: `bullish_ds=${directionalScore.toFixed(3)}_th=${directionalThreshold.toFixed(3)}`
+    };
   }
 
-  if (directionalScore < -0.2) {
-    return { action: "sell", amount: baseAmount, reason: `bearish_score_${directionalScore.toFixed(2)}` };
+  if (directionalScore < -directionalThreshold) {
+    return {
+      action: "sell",
+      amount: baseAmount,
+      reason: `bearish_ds=${directionalScore.toFixed(3)}_th=${directionalThreshold.toFixed(3)}`
+    };
   }
 
-  const conservative = difficulty === "hard" ? Math.round(baseAmount * 0.6) : Math.round(baseAmount * 0.45);
-  return { action: "hold", amount: conservative, reason: `neutral_score_${directionalScore.toFixed(2)}` };
+  const neutralTradeChance = difficulty === "easy" ? 0.22 : difficulty === "normal" ? 0.38 : 0.55;
+  if (Math.random() < neutralTradeChance) {
+    const fallbackBias = momentum + shortTrend;
+    const action = fallbackBias >= 0 ? "buy" : "sell";
+    const conservativeAmount = difficulty === "hard" ? Math.round(baseAmount * 0.7) : Math.round(baseAmount * 0.5);
+    return {
+      action,
+      amount: clamp(conservativeAmount, CPU_STRATEGY_CONSTANTS.minTradeAmount, CPU_STRATEGY_CONSTANTS.maxTradeAmount),
+      reason: `neutral_follow_bias=${fallbackBias.toFixed(3)}_ds=${directionalScore.toFixed(3)}`
+    };
+  }
+
+  const conservative = difficulty === "hard" ? Math.round(baseAmount * 0.55) : Math.round(baseAmount * 0.4);
+  return {
+    action: "hold",
+    amount: conservative,
+    reason: `neutral_hold_ds=${directionalScore.toFixed(3)}_th=${directionalThreshold.toFixed(3)}`
+  };
 }
 
 export function decideCpuAction(difficulty: CpuDifficulty, context: BattleContext): CpuDecision {

--- a/apps/server/src/services/gameService.ts
+++ b/apps/server/src/services/gameService.ts
@@ -183,6 +183,19 @@ export async function resolveTurn(input: ResolveTurnInput) {
     amount: clamp(cpuDecision.amount, 0, GAME_CONFIG.maxInvestmentPerTurn),
     itemType: cpuDecision.itemId === "PRICE_SPIKE" ? ItemType.PRICE_SPIKE : undefined
   };
+  auditLog("CPU_DECISION_EVALUATED", {
+    matchId: match.id,
+    turnNumber: match.turnNumber,
+    subturnBeforeResolve: (matchSubturnCounts.get(match.id) ?? 0) + 1,
+    cpuAction: cpuDecision.action,
+    cpuAmountRequested: cpuDecision.amount,
+    cpuAmountApplied: botMove.amount,
+    cpuItem: cpuDecision.itemId ?? null,
+    cpuReason: cpuDecision.reason,
+    currentPrice: battleContext.currentPrice,
+    initialPrice: battleContext.initialPrice,
+    priceHistoryCount: battleContext.priceHistory.length
+  });
 
   const effectState = matchEffects.get(match.id) ?? { shieldUntilTurn: {}, doubleForceUntilTurn: {} };
   const playerDoubleForce = effectState.doubleForceUntilTurn[player.side] === match.turnNumber ? 2 : 1;
@@ -300,22 +313,30 @@ export async function resolveTurn(input: ResolveTurnInput) {
 
   let status: MatchStatus = MatchStatus.ACTIVE;
   let winnerSide: Side | null = null;
+  const isTargetReachMode = GAME_CONFIG.victoryConditionMode === "TARGET_REACH";
+  const reachedUpper = close >= Number(match.targetUpperPrice);
+  const reachedLower = close <= Number(match.targetLowerPrice);
+  const reachedTurnLimit = match.turnNumber >= match.maxTurns && currentSubturn >= 3;
 
-  if (close >= Number(match.targetUpperPrice)) {
-    status = MatchStatus.FINISHED;
-  } else if (close <= Number(match.targetLowerPrice)) {
-    status = MatchStatus.FINISHED;
-  } else if (match.turnNumber >= match.maxTurns && currentSubturn >= 3) {
+  if (isTargetReachMode) {
+    if (reachedUpper || reachedLower || reachedTurnLimit) {
+      status = MatchStatus.FINISHED;
+    }
+  } else if (reachedTurnLimit) {
     status = MatchStatus.FINISHED;
   }
 
   if (status === MatchStatus.FINISHED) {
     closeAllOpenPositions(match.id, close, match.turnNumber);
-    const pnlBySide = calculatePnlBySide(
-      match.id,
-      new Map(match.players.map((p) => [p.userId, p.side]))
-    );
-    winnerSide = pnlBySide.BUY === pnlBySide.SELL ? null : pnlBySide.BUY > pnlBySide.SELL ? Side.BUY : Side.SELL;
+    if (isTargetReachMode && (reachedUpper || reachedLower)) {
+      winnerSide = reachedUpper ? Side.BUY : Side.SELL;
+    } else {
+      const pnlBySide = calculatePnlBySide(
+        match.id,
+        new Map(match.players.map((p) => [p.userId, p.side]))
+      );
+      winnerSide = pnlBySide.BUY === pnlBySide.SELL ? null : pnlBySide.BUY > pnlBySide.SELL ? Side.BUY : Side.SELL;
+    }
   }
 
   const nextTurnNumber = status === MatchStatus.FINISHED ? match.turnNumber : currentSubturn >= 3 ? match.turnNumber + 1 : match.turnNumber;
@@ -357,6 +378,14 @@ export async function resolveTurn(input: ResolveTurnInput) {
     turnNumber: match.turnNumber,
     subturn: currentSubturn,
     actionType: input.action.actionType,
+    playerAmount: playerEffectiveAmount,
+    cpuActionType: botMove.actionType,
+    cpuAmount: cpuEffectiveAmount,
+    cpuReason: cpuDecision.reason,
+    victoryConditionMode: GAME_CONFIG.victoryConditionMode,
+    reachedUpper,
+    reachedLower,
+    reachedTurnLimit,
     buyTotal,
     sellTotal,
     close


### PR DESCRIPTION
### Motivation
- Make match victory rules configurable between target-reach and PnL-battle modes and expose the mode at runtime for observability.
- Improve CPU action selection to be more responsive to short-term trend signals and provide clearer decision reasons for debugging and analytics.
- Simplify and improve the mobile battle screen UX by consolidating controls, exposing match/debug identifiers, and improving spacing.

### Description
- Add a new `victoryConditionMode` to `GAME_CONFIG` driven by `process.env.GAME_VICTORY_CONDITION` and typed as `VictoryConditionMode`.
- Update `resolveTurn` to honor `victoryConditionMode` so matches can finish immediately on hitting upper/lower targets in `TARGET_REACH` mode, otherwise finish by turn-limit and determine winner by PnL; also include richer audit logs and CPU/player amount details in `TURN_RESOLVED` and log CPU decision via `CPU_DECISION_EVALUATED`.
- Revamp CPU decision logic in `cpuStrategy.ts` by adding a short-term `shortTrend` signal, reweighting `directionalScore`, introducing difficulty-specific thresholds and neutral trade behavior, refining fallback amounts, and producing more descriptive `reason` strings.
- Update the mobile battle UI (`apps/mobile/app/battle.tsx`) to combine turn/subturn display, move lot selection and item buttons into the chart-tap panel, change winner labeling to use `selfPnl`/`opponentPnl` text, add subtle spacing tweaks, and surface `Match` and API/debug metadata in the footer.

### Testing
- Ran backend unit tests and TypeScript type checks (`pnpm --filter apps/server test` and `pnpm -w run typecheck`), which completed without failures.
- Built the mobile app and performed a smoke UI check (`yarn workspace apps/mobile build`), and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0581a9d7c832caf5116075cb2bab7)